### PR TITLE
[add] status_btn

### DIFF
--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -12,6 +12,13 @@
             <% end %>
             <%= item.name %><br>
             ¥<%= item.with_tax_price.to_s(:delimited) %>
+            <div class="">
+              <% if item.status == "販売中" %>
+                <b class="text-success"><%= item.status %></b>
+              <% else %>
+                <b class="text-secondary"><%= item.status %></b>
+              <% end %>
+            </div>
           </div>
         </div>
       <% end %>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -9,12 +9,15 @@
     <h5><%= @item.introduction %></h5><br>
     <h5><b>￥<%= @item.with_tax_price.to_s(:delimited) %></b>(税込）</h5><br>
 
-    <% if current_customer %>
+    <% if current_customer && @item.status == "販売中" %>
+      <b class="text-success"><%= @item.status %></b>
       <%= form_with model: @cart_item, method: :post do |f| %>
         <%= f.select :count, *[1..10], prompt: "個数選択" %>
         <%= f.hidden_field :item_id, :value => @item.id %>
         <%= f.submit 'カートに入れる', class:"btn btn-success ml-3" %>
       <% end %>
+    <% elsif @item.status == "販売停止中" %>
+      <b class="text-secondary"><%= @item.status %></b>
     <% else %>
       <p>商品購入には会員登録が必要です。</p>
       <%= link_to '新規登録はこちら', new_customer_registration_path, class:"text-info my-3" %>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -1,3 +1,4 @@
+
 <div class="row">
   <div class="col-md-3 offset-1">
     <h2 class="text-center bg-light">注文情報確認</h2>


### PR DESCRIPTION
## パブリック側に商品ステータス表示販売機能追加
- カートに追加できないように表示を条件分岐させました。
- 一覧画面、詳細画面で販売ステータスを表示しました。